### PR TITLE
Add seismometer animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,26 +5,19 @@
   <title>Cool 3D Graphics</title>
   <style>
     body { margin: 0; overflow: hidden; background: black; font-family: sans-serif; }
-    .label {
-      color: white;
-      background: rgba(0, 0, 0, 0.6);
-      padding: 5px 10px;
-      border-radius: 5px;
-      position: absolute;
-      pointer-events: none;
-      font-weight: bold;
+    #wave {
+      width: 100%;
     }
   </style>
 </head>
 <body>
-  <div id="label1" class="label">Debajeet</div>
-  <div id="label2" class="label">Barman</div>
+  <canvas id="wave"></canvas>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r148/three.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/three@0.148.0/examples/js/controls/OrbitControls.js"></script>
   <script>
     const scene = new THREE.Scene();
-    const camera = new THREE.PerspectiveCamera(75, window.innerWidth/window.innerHeight, 0.1, 1000);
-    camera.position.z = 5;
+    const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera.position.set(0, 1.5, 4);
 
     const renderer = new THREE.WebGLRenderer();
     renderer.setSize(window.innerWidth, window.innerHeight);
@@ -32,37 +25,66 @@
 
     const controls = new THREE.OrbitControls(camera, renderer.domElement);
 
-    const geometry = new THREE.BoxGeometry(1.5, 1, 0.1);
-    const material = new THREE.MeshStandardMaterial({ color: 0x00ffff });
-    const card1 = new THREE.Mesh(geometry, material);
-    const card2 = new THREE.Mesh(geometry, material);
-    scene.add(card1);
-    scene.add(card2);
+    // Base
+    const base = new THREE.Mesh(
+      new THREE.BoxGeometry(4, 0.2, 2),
+      new THREE.MeshStandardMaterial({ color: 0x333333 })
+    );
+    base.position.y = 0;
+    scene.add(base);
+
+    // Rotating drum
+    const drum = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.5, 0.5, 2, 32),
+      new THREE.MeshStandardMaterial({ color: 0xffffff })
+    );
+    drum.rotation.x = Math.PI / 2; // lay horizontally
+    drum.position.y = 0.6;
+    scene.add(drum);
+
+    // Pen arm
+    const pen = new THREE.Mesh(
+      new THREE.BoxGeometry(0.05, 0.6, 0.05),
+      new THREE.MeshStandardMaterial({ color: 0xff0000 })
+    );
+    pen.position.set(0.55, 0.9, 0);
+    scene.add(pen);
 
     const light = new THREE.PointLight(0xffffff, 1);
-    light.position.set(10, 10, 10);
+    light.position.set(5, 5, 5);
     scene.add(light);
 
-    function updateLabelPosition(labelId, obj) {
-      const vector = new THREE.Vector3();
-      obj.updateMatrixWorld();
-      vector.setFromMatrixPosition(obj.matrixWorld);
-      vector.project(camera);
-      const x = (vector.x * 0.5 + 0.5) * window.innerWidth;
-      const y = (-vector.y * 0.5 + 0.5) * window.innerHeight;
-      const label = document.getElementById(labelId);
-      label.style.transform = `translate(-50%, -50%) translate(${x}px,${y}px)`;
+    const waveCanvas = document.getElementById('wave');
+    const waveCtx = waveCanvas.getContext('2d');
+    waveCanvas.width = window.innerWidth;
+    waveCanvas.height = 150;
+    waveCanvas.style.position = 'absolute';
+    waveCanvas.style.bottom = '0';
+    waveCanvas.style.left = '0';
+    waveCanvas.style.pointerEvents = 'none';
+
+    let waveData = new Array(waveCanvas.width).fill(waveCanvas.height / 2);
+
+    function drawWave(value) {
+      waveData.push(waveCanvas.height / 2 - value * 100);
+      if (waveData.length > waveCanvas.width) waveData.shift();
+      waveCtx.fillStyle = '#000';
+      waveCtx.fillRect(0, 0, waveCanvas.width, waveCanvas.height);
+      waveCtx.beginPath();
+      for (let i = 0; i < waveData.length; i++) {
+        waveCtx.lineTo(i, waveData[i]);
+      }
+      waveCtx.strokeStyle = '#00ff00';
+      waveCtx.stroke();
     }
 
     function animate(t) {
       requestAnimationFrame(animate);
       const time = t * 0.001;
-      card1.position.x = Math.sin(time) * 2;
-      card1.position.z = Math.cos(time) * 2;
-      card2.position.x = -Math.sin(time) * 2;
-      card2.position.z = -Math.cos(time) * 2;
-      updateLabelPosition("label1", card1);
-      updateLabelPosition("label2", card2);
+      const amp = Math.sin(time * 3) * 0.2 + (Math.random() - 0.5) * 0.05;
+      drum.rotation.z += 0.01;
+      pen.position.y = 0.9 + amp;
+      drawWave(amp);
       controls.update();
       renderer.render(scene, camera);
     }
@@ -70,9 +92,12 @@
     animate();
 
     window.addEventListener('resize', () => {
-      camera.aspect = window.innerWidth/window.innerHeight;
+      camera.aspect = window.innerWidth / window.innerHeight;
       camera.updateProjectionMatrix();
       renderer.setSize(window.innerWidth, window.innerHeight);
+      waveCanvas.width = window.innerWidth;
+      waveCanvas.height = 150;
+      waveData = new Array(waveCanvas.width).fill(waveCanvas.height / 2);
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- switch to a new scene with a rotating drum and moving pen
- overlay a canvas that draws a seismograph waveform

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fbcecad888331866b10282c3244ce